### PR TITLE
Fix worker cancel method and add GUI launcher

### DIFF
--- a/src/gui/gui_app.py
+++ b/src/gui/gui_app.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3.12
+# -*- coding: utf-8 -*-
+"""GUI 启动入口 (兼容旧路径)"""
+import sys
+from pathlib import Path
+from PyQt6.QtWidgets import QApplication
+
+if __package__ is None or __package__ == "":
+    project_root = Path(__file__).resolve().parents[1]
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+from src.gui.main_window import MainWindow
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    win = MainWindow()
+    win.show()
+    sys.exit(app.exec())

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -26,9 +26,14 @@ from PyQt6 import uic
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QProgressDialog
 )
+from PyQt6.QtCore import QThread
 from src.workers.display_worker import DisplayWorker
-from src.processing.task_manager import TaskManager
 from src.workers.processing_worker import ProcessingWorker
+from src.workers.file_worker import FileWorker
+from src.workers.file_saver_worker import FileSaverWorker
+from src.workers.vector_worker import VectorWorker
+from src.processing.task_manager import TaskManager
+from src.processing.task_result import TaskResult
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -44,18 +49,92 @@ class MainWindow(QMainWindow):
         self.progressDialog = QProgressDialog(self)
         self.progressDialog.setAutoClose(False)
         self.progressDialog.setLabelText("准备中…")
+        self.progressDialog.hide()
+        # 取消按钮关闭当前线程
+        self.progressDialog.canceled.connect(self.cancel_current_worker)
 
-        # 统一加载所有菜单动作的槽
-        
-        
+        # 当前运行的后台线程引用，避免被垃圾回收
+        self.current_worker: QThread | None = None
+
+        # 绑定部分菜单动作到后台任务
+        if hasattr(self, 'actionOpenImageFile'):
+            self.actionOpenImageFile.triggered.connect(self.run_file_operation)
+        if hasattr(self, 'actionOpenVectorData'):
+            self.actionOpenVectorData.triggered.connect(self.run_vector_processing)
+        if hasattr(self, 'actionSaveImageFileAs'):
+            self.actionSaveImageFileAs.triggered.connect(self.run_file_save)
+        if hasattr(self, 'actionSaveVectorFileAs'):
+            self.actionSaveVectorFileAs.triggered.connect(self.run_vector_processing)
+        if hasattr(self, 'actionExit'):
+            self.actionExit.triggered.connect(self.close)
+        if hasattr(self, 'actionBandextraction'):
+            self.actionBandextraction.triggered.connect(self.run_image_display)
+        if hasattr(self, 'actionImagestretching'):
+            self.actionImagestretching.triggered.connect(self.run_image_processing)
+
         # TODO: 为其他 actionXXX 依次绑定对应的槽函数
 
 
-    def _on_task_complete(self, name: str, result_path: str):
-        """统一任务完成处理"""
+
+    # ===== 后台任务接口 =====
+    def _start_worker(self, worker: QThread, title: str):
+        """通用启动方法"""
+        # 保存当前线程引用，避免被回收
+        self.current_worker = worker
+
+        worker.progress.connect(self.progressDialog.setLabelText)
+        worker.finished.connect(lambda res: self._handle_result(title, res))
+        worker.finished.connect(self._clear_current_worker)
+
+        self.progressDialog.setLabelText(f"{title}…")
+        self.progressDialog.show()
+        worker.start()
+
+    def _handle_result(self, title: str, result: TaskResult):
         self.progressDialog.hide()
-        self.statusBar().showMessage(f"{name} 完成，结果保存在 {result_path}", 5000)
-        # TODO: 在图层面板中加载结果文件
+        if result.status == "success":
+            msg = f"{title}完成"
+        else:
+            msg = f"{title}失败: {result.message}"
+        self.statusBar().showMessage(msg, 5000)
+
+
+    def cancel_current_worker(self):
+        """取消当前运行的后台线程"""
+        if self.current_worker and self.current_worker.isRunning():
+            self.current_worker.terminate()
+
+    # 向后兼容旧接口
+    def _cancel_current_worker(self):
+        self.cancel_current_worker()
+
+    def _clear_current_worker(self):
+        self.current_worker = None
+
+    def run_file_operation(self):
+        params = getattr(self.task_manager.config, "file_operation_params", {})
+        worker = FileWorker(params=params)
+        self._start_worker(worker, "文件加载")
+
+    def run_image_display(self):
+        params = getattr(self.task_manager.config, "image_display_params", {})
+        worker = DisplayWorker(params=params)
+        self._start_worker(worker, "波段可视化")
+
+    def run_image_processing(self):
+        params = getattr(self.task_manager.config, "image_processing_params", {})
+        worker = ProcessingWorker(params=params)
+        self._start_worker(worker, "图像处理")
+
+    def run_file_save(self):
+        params = getattr(self.task_manager.config, "file_saver_params", {})
+        worker = FileSaverWorker(params=params)
+        self._start_worker(worker, "文件保存")
+
+    def run_vector_processing(self):
+        params = getattr(self.task_manager.config, "vector_processing_params", {})
+        worker = VectorWorker(params=params)
+        self._start_worker(worker, "矢量处理")
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)

--- a/src/gui_app.py
+++ b/src/gui_app.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3.12
+# -*- coding: utf-8 -*-
+"""GUI 启动入口"""
+import sys
+from pathlib import Path
+from PyQt6.QtWidgets import QApplication
+
+if __package__ is None or __package__ == "":
+    project_root = Path(__file__).resolve().parent.parent
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+from src.gui.main_window import MainWindow
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    win = MainWindow()
+    win.show()
+    sys.exit(app.exec())

--- a/src/workers/file_saver_worker.py
+++ b/src/workers/file_saver_worker.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3.12
+# -*- coding: utf-8 -*-
+"""后台线程：执行文件保存任务"""
+from PyQt6.QtCore import QThread, pyqtSignal
+from src.processing.task_manager import TaskManager
+from src.processing.task_result import TaskResult
+
+
+class FileSaverWorker(QThread):
+    """执行 file_saver 任务并发出进度与完成信号"""
+
+    progress = pyqtSignal(str)
+    finished = pyqtSignal(TaskResult)
+
+    def __init__(self, config_path: str | None = None, params: dict | None = None):
+        super().__init__()
+        self.manager = TaskManager(config_path)
+        self.task_name = "file_saver"
+        self.params = params or {}
+
+    def run(self) -> None:
+        self.progress.emit(f"开始任务: {self.task_name}")
+        result = self.manager.run_task(self.task_name, self.params)
+        self.finished.emit(result)


### PR DESCRIPTION
## Summary
- expose `cancel_current_worker` and keep `_cancel_current_worker` for compatibility
- connect progress dialog cancel signal to the new method
- provide `gui/gui_app.py` so old paths still work

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `QT_QPA_PLATFORM=offscreen python3 src/gui_app.py` *(fails: ImportError: libEGL.so.1)*


------
https://chatgpt.com/codex/tasks/task_e_6852ba2685488326b70173fc5ab5a140