### PR TITLE
Integrate file dialogs with processing backend

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -24,8 +24,9 @@ if __package__ is None or __package__ == "":
 import os
 from PyQt6 import uic
 from PyQt6.QtWidgets import (
-    QApplication, QMainWindow, QProgressDialog
+    QApplication, QMainWindow, QProgressDialog, QDialog, QFileDialog
 )
+from functools import partial
 from PyQt6.QtCore import QThread
 from src.workers.display_worker import DisplayWorker
 from src.workers.processing_worker import ProcessingWorker
@@ -56,23 +57,137 @@ class MainWindow(QMainWindow):
         # 当前运行的后台线程引用，避免被垃圾回收
         self.current_worker: QThread | None = None
 
-        # 绑定部分菜单动作到后台任务
-        if hasattr(self, 'actionOpenImageFile'):
-            self.actionOpenImageFile.triggered.connect(self.run_file_operation)
-        if hasattr(self, 'actionOpenVectorData'):
-            self.actionOpenVectorData.triggered.connect(self.run_vector_processing)
-        if hasattr(self, 'actionSaveImageFileAs'):
-            self.actionSaveImageFileAs.triggered.connect(self.run_file_save)
-        if hasattr(self, 'actionSaveVectorFileAs'):
-            self.actionSaveVectorFileAs.triggered.connect(self.run_vector_processing)
+        # 对应 UI 文件目录
+        self.ui_dir = os.path.join(os.path.dirname(__file__), 'ui', 'yaogan')
+
+        # ========== 菜单与对话框绑定 ==========
+        # File 菜单的四个动作需要与后台任务交互，单独处理
+        file_actions = {
+            'actionOpenImageFile': self.show_open_image_dialog,
+            'actionOpenVectorData': self.show_open_vector_dialog,
+            'actionSaveImageFileAs': self.show_save_image_dialog,
+            'actionSaveVectorFileAs': self.show_save_vector_dialog,
+        }
+
+        # 其余动作仅弹出对应的 ui
+        dialog_map = {
+            'actionBandextraction':     'ImageDisplay/Band_extraction.ui',
+            'actionBandsynthesis':      'ImageDisplay/Band_synthesis.ui',
+            'actionHistogram':          'ImageDisplay/Histogram.ui',
+            'actionProjection':         'ImageDisplay/Projection.ui',
+            'actionviewingmetadata':    'ImageDisplay/Viewing_metadata.ui',
+            'actionBandMath':           'ImageProcessing/Band_math.ui',
+            'actionEdgedetection':      'ImageProcessing/Edge_detection.ui',
+            'actionSharpening':         'ImageProcessing/Sharpening.ui',
+            'actionSmoothing':          'ImageProcessing/Smoothing.ui',
+        }
+        for action_name, slot in file_actions.items():
+            if hasattr(self, action_name):
+                getattr(self, action_name).triggered.connect(slot)
+
+        for action_name, ui_rel in dialog_map.items():
+            if hasattr(self, action_name):
+                getattr(self, action_name).triggered.connect(
+                    partial(self.show_ui_dialog, ui_rel)
+                )
+
         if hasattr(self, 'actionExit'):
             self.actionExit.triggered.connect(self.close)
-        if hasattr(self, 'actionBandextraction'):
-            self.actionBandextraction.triggered.connect(self.run_image_display)
-        if hasattr(self, 'actionImagestretching'):
-            self.actionImagestretching.triggered.connect(self.run_image_processing)
 
-        # TODO: 为其他 actionXXX 依次绑定对应的槽函数
+        # 旧版后台任务入口保留（未连接到菜单）
+
+    def show_ui_dialog(self, ui_relative_path: str):
+        """根据相对路径加载并显示一个对话框"""
+        path = os.path.join(self.ui_dir, ui_relative_path)
+        dialog = QDialog(self)
+        uic.loadUi(path, dialog)
+        dialog.exec()
+
+    # ------ File 菜单专用对话框 ------
+    def show_open_image_dialog(self):
+        path = os.path.join(self.ui_dir, 'File', 'open_image_file.ui')
+        dialog = QDialog(self)
+        uic.loadUi(path, dialog)
+        if hasattr(dialog, 'Open'):
+            dialog.Open.clicked.connect(lambda: self._open_image(dialog))
+        if hasattr(dialog, 'pushButton_2'):
+            dialog.pushButton_2.clicked.connect(dialog.reject)
+        dialog.exec()
+
+    def _open_image(self, dialog: QDialog):
+        directory = QFileDialog.getExistingDirectory(self, '选择影像文件夹')
+        if not directory:
+            return
+        if hasattr(dialog, 'lineEdit'):
+            dialog.lineEdit.setText(directory)
+        params = {'input_dir': directory}
+        self.run_file_operation(params)
+        dialog.accept()
+
+    def show_open_vector_dialog(self):
+        path = os.path.join(self.ui_dir, 'File', 'open_vector_data.ui')
+        dialog = QDialog(self)
+        uic.loadUi(path, dialog)
+        if hasattr(dialog, 'pushButton'):
+            dialog.pushButton.clicked.connect(lambda: self._open_vector(dialog))
+        if hasattr(dialog, 'pushButton_2'):
+            dialog.pushButton_2.clicked.connect(dialog.reject)
+        dialog.exec()
+
+    def _open_vector(self, dialog: QDialog):
+        files, _ = QFileDialog.getOpenFileNames(
+            self,
+            '选择矢量文件',
+            '',
+            'Vector Files (*.shp *.geojson *.json *.gpkg)'
+        )
+        if not files:
+            return
+        if hasattr(dialog, 'lineEdit'):
+            dialog.lineEdit.setText(files[0])
+        params = {'input_paths': files}
+        self.run_vector_processing(params)
+        dialog.accept()
+
+    def show_save_image_dialog(self):
+        path = os.path.join(self.ui_dir, 'File', 'save_image_as.ui')
+        dialog = QDialog(self)
+        uic.loadUi(path, dialog)
+        if hasattr(dialog, 'pushButton'):
+            dialog.pushButton.clicked.connect(lambda: self._save_image(dialog))
+        if hasattr(dialog, 'pushButton_2'):
+            dialog.pushButton_2.clicked.connect(dialog.reject)
+        dialog.exec()
+
+    def _save_image(self, dialog: QDialog):
+        directory = QFileDialog.getExistingDirectory(self, '选择保存目录')
+        if not directory:
+            return
+        if hasattr(dialog, 'lineEdit'):
+            dialog.lineEdit.setText(directory)
+        params = {'save_dir': directory}
+        self.run_file_save(params)
+        dialog.accept()
+
+    def show_save_vector_dialog(self):
+        path = os.path.join(self.ui_dir, 'File', 'save_vector_as.ui')
+        dialog = QDialog(self)
+        uic.loadUi(path, dialog)
+        if hasattr(dialog, 'pushButton'):
+            dialog.pushButton.clicked.connect(lambda: self._save_vector(dialog))
+        if hasattr(dialog, 'pushButton_2'):
+            dialog.pushButton_2.clicked.connect(dialog.reject)
+        dialog.exec()
+
+    def _save_vector(self, dialog: QDialog):
+        directory = QFileDialog.getExistingDirectory(self, '选择保存目录')
+        if not directory:
+            return
+        if hasattr(dialog, 'lineEdit'):
+            dialog.lineEdit.setText(directory)
+        params = {'output_dir': directory}
+        self.run_vector_processing(params)
+        dialog.accept()
 
 
 
@@ -111,9 +226,11 @@ class MainWindow(QMainWindow):
     def _clear_current_worker(self):
         self.current_worker = None
 
-    def run_file_operation(self):
-        params = getattr(self.task_manager.config, "file_operation_params", {})
-        worker = FileWorker(params=params)
+    def run_file_operation(self, override: dict | None = None):
+        base = getattr(self.task_manager.config, "file_operation_params", {}).copy()
+        if override:
+            base.update(override)
+        worker = FileWorker(params=base)
         self._start_worker(worker, "文件加载")
 
     def run_image_display(self):
@@ -126,14 +243,18 @@ class MainWindow(QMainWindow):
         worker = ProcessingWorker(params=params)
         self._start_worker(worker, "图像处理")
 
-    def run_file_save(self):
-        params = getattr(self.task_manager.config, "file_saver_params", {})
-        worker = FileSaverWorker(params=params)
+    def run_file_save(self, override: dict | None = None):
+        base = getattr(self.task_manager.config, "file_saver_params", {}).copy()
+        if override:
+            base.update(override)
+        worker = FileSaverWorker(params=base)
         self._start_worker(worker, "文件保存")
 
-    def run_vector_processing(self):
-        params = getattr(self.task_manager.config, "vector_processing_params", {})
-        worker = VectorWorker(params=params)
+    def run_vector_processing(self, override: dict | None = None):
+        base = getattr(self.task_manager.config, "vector_processing_params", {}).copy()
+        if override:
+            base.update(override)
+        worker = VectorWorker(params=base)
         self._start_worker(worker, "矢量处理")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- connect File menu dialogs to backend workers
- allow overriding parameters when starting tasks
- open/save dialogs now trigger processing threads

## Testing
- `pip install -r requirements.txt -q` *(fails: gdal-config missing)*
- `pytest -q`
- `python -m py_compile src/gui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_6852cdcb9e948326ad8b91e1ac82ee61